### PR TITLE
Add skeleton for memecoin analysis bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
-# prueba140
+# Bot de Análisis y Alerta de Memecoins en Solana
+
+Este proyecto contiene el esqueleto de un bot escrito en **Python** que analiza memecoins en la red **Solana**. Integra datos on-chain, de mercado y sociales para calcular un *score* compuesto y detectar oportunidades o riesgos.
+
+## Resumen ejecutivo
+El bot filtra posibles *rug pulls* (liquidez bloqueada, autoridades renunciadas, distribución de holders) y combina información de diferentes APIs. Genera notificaciones por Telegram y Discord, almacenando datos en PostgreSQL y Redis. Todas las claves de API se leen desde variables de entorno.
+
+## Diagrama de alto nivel
+```
++-------------+      +-------------+      +-------------+
+| data_feeds  | ---> | analysis    | ---> | scoring     |
+| (on-chain,  |      | _engine     |      |             |
+| mercado,    |      +-------------+      +-------------+
+| social,     |              |                   |
+| rugcheck)   |              v                   v
++-------------+      +-------------+      +-------------+
+                           |                   |
+                       +-------+          +---------+
+                       | DB    |<---------| notifier|
+                       +-------+          +---------+
+                           ^
+                           |
+                    +--------------+
+                    |  rug_check   |
+                    +--------------+
+```
+
+## Módulos principales
+- `data_feeds`: conexiones a WebSockets y APIs (Solscan, DexScreener, Birdeye).
+- `rug_check`: validación de liquidez, autoridades y listas negras.
+- `analysis_engine`: fusiona datos y aplica reglas de trading.
+- `scoring`: calcula el *score* compuesto de cada token.
+- `notifier`: envía alertas a Telegram y Discord.
+- `main.py`: orquestación general con `asyncio`.
+
+## Tabla de umbrales
+| Parámetro                             | Valor por defecto | Variable |
+|---------------------------------------|------------------|----------|
+| LP bloqueado o quemado                | 100 %            | `MIN_LP_LOCK` |
+| Liquidez inicial mínima             | 50 k USDC        | `MIN_LIQ_USDC` |
+| Distribución Top 1 / Top 5           | <10 % / <25 %    | `MAX_TOP1`, `MAX_TOP5` |
+| Supply quemado "verde"                | ≥30 %          | `MIN_BURN_PCT` |
+| Volumen intra-hora para alerta        | >100 k USDC      | `ALERT_VOL_1H` |
+| Incremento precio intra-hora          | ≥20 %          | `ALERT_PCT_15M` |
+| Score mínimo para notificación       | ≥70           | `ALERT_SCORE` |
+
+## Ejemplo de mensaje de alerta
+```
+🚨 Nuevo memecoin en tendencia: ABC
+Score total: 74/100
+• Seguridad: 45/50
+• Momentum mercado: 20/30
+• Tracción social: 9/15
+• Smart-money: 0/5
+Liquidez inicial 120k USDC, LP bloqueado 100 %
+```
+
+## Checklist diaria
+1. Rotar claves de API (Helius, DexScreener, Twitter).
+2. Verificar límites de llamadas y ajustar frecuencias.
+3. Revisar logs en Loki para fallos de conexión.
+4. Actualizar listas negras de RugCheck/SolSniffer.
+5. Confirmar tamaño de PostgreSQL y Redis.
+6. Reiniciar procesos si hay actualizaciones.
+7. Probar bot de Telegram/Discord con un mensaje.
+
+Este repositorio sirve como base para un bot completo de seguimiento de memecoins en Solana.

--- a/bot/analysis_engine.py
+++ b/bot/analysis_engine.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+from typing import Any
+from datetime import datetime
+
+class AnalysisEngine:
+    """Agrega datos de distintas fuentes y aplica reglas."""
+    def __init__(self, feeds: Any, db: Any) -> None:
+        self.feeds = feeds
+        self.db = db
+
+    async def update_coin(self, coin: str) -> None:
+        price = await self.feeds.fetch_price(coin)
+        social = await self.feeds.fetch_social(coin)
+        risk = await self.feeds.rug_check(coin)
+        await self.db.save_snapshot(coin, price, social, risk)
+
+    async def detect_opportunities(self) -> list[dict]:
+        rows = await self.db.get_recent_data()
+        opportunities = []
+        for row in rows:
+            # Lógica de detección según umbrales
+            pass
+        return opportunities

--- a/bot/data_feeds.py
+++ b/bot/data_feeds.py
@@ -1,0 +1,21 @@
+import os
+import asyncio
+import aiohttp
+import websockets
+
+HELIUS_KEY = os.getenv("HELIUS_KEY")
+DEX_WS = "wss://io.dexscreener.com/ws"
+
+async def fetch_solscan(address: str) -> dict:
+    """Consulta datos de tokens en Solscan."""
+    url = f"https://api.solscan.io/account/tokens?address={address}"
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as resp:
+            return await resp.json()
+
+async def dex_ws_listener(queue: asyncio.Queue) -> None:
+    """Escucha pares nuevos mediante WebSocket de DexScreener."""
+    async with websockets.connect(DEX_WS) as ws:
+        await ws.send('{"type":"subscribe","topic":"pairs"}')
+        async for msg in ws:
+            await queue.put(msg)

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,0 +1,17 @@
+import asyncio
+from . import data_feeds, analysis_engine
+
+async def main() -> None:
+    queue: asyncio.Queue = asyncio.Queue()
+    feeds = ...  # Implementación de feeds
+    db = ...     # Implementación de base de datos
+    engine = analysis_engine.AnalysisEngine(feeds=feeds, db=db)
+    asyncio.create_task(data_feeds.dex_ws_listener(queue))
+    while True:
+        msg = await queue.get()
+        coin = ...  # Parseo de mensaje
+        await engine.update_coin(coin)
+        await engine.detect_opportunities()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/bot/notifier.py
+++ b/bot/notifier.py
@@ -1,0 +1,15 @@
+import os
+import aiohttp
+
+TELEGRAM_TOKEN = os.getenv("TG_TOKEN")
+TELEGRAM_CHAT = os.getenv("TG_CHAT")
+DISCORD_WEBHOOK = os.getenv("DISCORD_HOOK")
+
+async def send_telegram(msg: str) -> None:
+    url = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/sendMessage"
+    async with aiohttp.ClientSession() as session:
+        await session.post(url, json={"chat_id": TELEGRAM_CHAT, "text": msg})
+
+async def send_discord(msg: str) -> None:
+    async with aiohttp.ClientSession() as session:
+        await session.post(DISCORD_WEBHOOK, json={"content": msg})

--- a/bot/rug_check.py
+++ b/bot/rug_check.py
@@ -1,0 +1,22 @@
+import os
+import aiohttp
+
+RUGCHECK_API = os.getenv("RUGCHECK_API")
+
+async def check_lp_locked(mint: str) -> bool:
+    """Verifica porcentaje de LP bloqueado y liquidez inicial."""
+    url = f"https://rugcheck.example.com/api/{mint}"
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as resp:
+            data = await resp.json()
+    return (
+        data.get("lp_locked_pct") == 100
+        and data.get("liquidity_usdc", 0) >= 50_000
+    )
+
+async def verify_authorities(mint_info: dict) -> bool:
+    """Confirma que mint y freeze authority estén renunciadas."""
+    return (
+        mint_info.get("mint_authority") is None
+        and mint_info.get("freeze_authority") is None
+    )

--- a/bot/scoring.py
+++ b/bot/scoring.py
@@ -1,0 +1,7 @@
+def compute_score(risk: dict, market: dict, social: dict, smart_money: dict) -> int:
+    """Calcula la puntuación compuesta de un token."""
+    seguridad = max(0, 50 - risk.get("penalizacion", 0))
+    momentum = min(30, market.get("var_5m", 0) + market.get("var_1h", 0) + market.get("var_24h", 0))
+    traccion = min(15, social.get("tweets_h", 0) + social.get("crec_telegram", 0))
+    smart = 5 if smart_money.get("compras_pct", 0) >= 0.5 else 0
+    return seguridad + momentum + traccion + smart

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+aiohttp
+websockets


### PR DESCRIPTION
## Summary
- add Python modules with async skeletons for data feed handling, risk checks, analysis engine, scoring, notifier and orchestration
- document architecture and maintenance in README
- add minimal requirements file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a1ca432808320b07f541343caca35